### PR TITLE
Uses fused-effects-0.3.0.0 from Hackage

### DIFF
--- a/fused-effects-exceptions.cabal
+++ b/fused-effects-exceptions.cabal
@@ -19,5 +19,5 @@ library
   exposed-modules:     Control.Effect.Catch
   build-depends:       base >= 4.7 && < 5
                        -- A proper version constraint will be provided when fused-effects hits 0.3
-                     , fused-effects
+                     , fused-effects   >= 0.3 && <1
                      , safe-exceptions >= 0.1 && <1

--- a/stack.yaml
+++ b/stack.yaml
@@ -2,7 +2,6 @@ resolver: lts-13.13
 
 packages:
 - .
-- location:
-    git: https://github.com/fused-effects/fused-effects
-    commit: 13b3c5f5871b6a637f5de7128865bcd305ba744e
-  extra-dep: true
+
+extra-deps:
+- fused-effects-0.3.0.0


### PR DESCRIPTION
Adds support fo `fused-effects-0.3.0.0` and above (I set the upperbound at `1` to mirror what you have in [`fused-effects-lens`](https://github.com/fused-effects/fused-effects-lens/blob/master/fused-effects-lens.cabal#L24)).