### PR TITLE
Adjust IORef carrier to handle new handleCoercible idiom.

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -3,4 +3,4 @@ packages: .
 source-repository-package
   type: git
   location: https://github.com/fused-effects/fused-effects.git
-  tag: 0c7d9c19b638f7fe21ac77903894308ad15b0e80
+  tag: e6282afa5eee744ccf733a1adecbd1db218e4d01

--- a/src/Control/Carrier/State/IORef.hs
+++ b/src/Control/Carrier/State/IORef.hs
@@ -68,5 +68,5 @@ instance (MonadIO m, Algebra sig m, Effect sig) => Algebra (State s :+: sig) (St
     case act of
       Put s k -> liftIO (writeIORef ref s) *> k
       Get k   -> liftIO (readIORef ref) >>= k
-  alg (R other) = StateC (handleCoercible other)
+  alg (R other) = StateC (alg (R (handleCoercible other)))
   {-# INLINE alg #-}


### PR DESCRIPTION
This brings us up to parity with what we expect the 1.0 interface to
look like.