### PR TITLE
GHC 9 support.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,12 @@
 name: Haskell CI
 
-on: [pull_request]
+on:
+  pull_request:
+    branches:
+      - "**"
+  push:
+    branches:
+      - "master"
 
 jobs:
   build:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,14 +8,14 @@ jobs:
     runs-on: ubuntu-16.04
     strategy:
       matrix:
-        ghc: ["8.2.2", "8.4.4", "8.6.5", "8.8.3", "8.10.1"]
+        ghc: ["8.2.2", "8.4.4", "8.6.5", "8.8.3", "8.10.1", "9.0.1"]
         cabal: ["latest"]
 
     steps:
     - uses: actions/checkout@v2
       if: github.event.action == 'opened' || github.event.action == 'synchronize' || github.event.ref == 'refs/heads/master'
 
-    - uses: actions/setup-haskell@v1.1.2
+    - uses: haskell/actions/setup@v1.1.8
       name: Setup Haskell
       with:
         ghc-version: ${{ matrix.ghc }}

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,7 +1,10 @@
+# 1.1.0.1
+
+* GHC 9 support.
+
 # 1.1.0.0
 
 * Port to fused-effects 1.1.
-
 
 # 1.0.0.0
 

--- a/fused-effects-exceptions.cabal
+++ b/fused-effects-exceptions.cabal
@@ -1,7 +1,7 @@
 cabal-version:       2.4
 
 name:                fused-effects-exceptions
-version:             1.1.0.0
+version:             1.1.0.1
 synopsis:            Handle exceptions thrown in IO with fused-effects.
 description:         Provides Resource and Catch effects capable of reacting to and catching GHC's dynamic exceptions.
 homepage:            https://github.com/fused-effects/fused-effects-exceptions#readme
@@ -22,6 +22,7 @@ tested-with:
   GHC == 8.6.5
   GHC == 8.8.3
   GHC == 8.10.1
+  GHC == 9.0.1
 
 common common
   default-language: Haskell2010

--- a/src/Control/Effect/Exception.hs
+++ b/src/Control/Effect/Exception.hs
@@ -166,7 +166,7 @@ mask with = liftWith $ \ run ctx -> Exc.mask $ \ restore ->
 --
 -- @since 1.0.0.0
 mask_ :: Has (Lift IO) sig m => m a -> m a
-mask_ m = mask $ const m
+mask_ m = mask (\_ -> m)
 
 -- | See @"Control.Exception".'Exc.uninterruptibleMask'@.
 --
@@ -179,7 +179,7 @@ uninterruptibleMask with = liftWith $ \ run ctx -> Exc.uninterruptibleMask $ \ r
 --
 -- @since 1.0.0.0
 uninterruptibleMask_ :: Has (Lift IO) sig m => m a -> m a
-uninterruptibleMask_ m = uninterruptibleMask $ const m
+uninterruptibleMask_ m = uninterruptibleMask (\_ -> m)
 
 -- | See @"Control.Exception".'Exc.getMaskingState'@.
 --


### PR DESCRIPTION
Apparently something in the typechecker got more ornery, because
passing the actions to `mask_` and `uninterruptibleMask_` using
`const` produced an error about not being able to instantiate
unification variables with polytypes.